### PR TITLE
updated the way "cc" is added to dict sent to mail_recipient()

### DIFF
--- a/ckanext/contact/routes/_helpers.py
+++ b/ckanext/contact/routes/_helpers.py
@@ -146,8 +146,12 @@ def submit():
 
         if( data_dict["contact-dest"] != "data-hub-support" and "pkg-id" in data_dict and data_dict["pkg-id"] != '' ):
             pkg = toolkit.get_action('package_show')(None, {'id': data_dict["pkg-id"] } )
-            mail_dict["headers"]["Cc"] =  mail_dict["recipient_email"] 
-            if( pkg["data_contact_email"] ): mail_dict["recipient_email"] = pkg["data_contact_email"]
+            if( pkg["data_contact_email"] ): 
+                # 'cc' needs to be in the mail header, and passed in as a parameter to mail_recipient both due to the way smtlib.sendmail works
+                mail_dict["headers"]["cc"] =  mail_dict["recipient_email"] 
+                mail_dict["cc"] =  [mail_dict["recipient_email"]]
+                
+                mail_dict["recipient_email"] = pkg["data_contact_email"]
 
 
         # allow other plugins to modify the mail_dict


### PR DESCRIPTION
Updated the way "cc" is added to messages to comply with the mail_recipient() signature as modified in  [TWDH Patch #6](https://github.com/twdbben/twdh-patches/blob/main/0006-Added-cc-bcc-reply-to-to-mail_recipients.patch) 